### PR TITLE
fix: Only provide 'credentials' key if actually explicit values set

### DIFF
--- a/src/Sns/SnsConnector.php
+++ b/src/Sns/SnsConnector.php
@@ -18,7 +18,9 @@ class SnsConnector
     {
         $config = $this->getDefaultConfiguration($config);
 
-        $config['credentials'] = Arr::only($config, ['key', 'secret']);
+        if (!empty($config['key']) && empty($config['secret'])) {
+            $config['credentials'] = Arr::only($config, ['key', 'secret']);
+        }
 
         return new Publisher(new SnsClient($config));
     }


### PR DESCRIPTION
If 'credentials' key is explicitly provided in config 'args' to a
SDK client, then the AWS PHP SDK will *not* follow its (recommended)
'Default Credential Provider Chain', which means it won't find and
use assumable roles in a pod in a EKS kubernetes cluster, not will
it default to the credentials file.

This fix ensures, that if the user has NOT set both 'key' and
'secret', the SDK will fallback to using the 'Default Credential
Provider Chain'.

See: https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html