### PR TITLE
Fix parse json format

### DIFF
--- a/src/Sqs/SqsJob.php
+++ b/src/Sqs/SqsJob.php
@@ -45,7 +45,7 @@ class SqsJob extends AbstractSqsJob
         $payload['job'] = $this->handler;
 
         if ($this->isJson($payload['Message']) === true) {
-            $payload['data'] = json_decode($payload['Message'], true);
+            $payload['data'] = $payload['Message'];
         } else {
             $payload['data'] = unserialize($payload['Message']);
         }

--- a/src/Sqs/SqsJob.php
+++ b/src/Sqs/SqsJob.php
@@ -44,8 +44,22 @@ class SqsJob extends AbstractSqsJob
 
         $payload['job'] = $this->handler;
 
-        $payload['data'] = unserialize($payload['Message']);
+        if ($this->isJson($payload['Message']) === true) {
+            $payload['data'] = json_decode($payload['Message'], true);
+        } else {
+            $payload['data'] = unserialize($payload['Message']);
+        }
 
         return $payload;
+    }
+
+    /**
+     * @param $message
+     * @return bool
+     */
+    private function isJson($message)
+    {
+        $result = json_decode(trim($message, '"'), true);
+        return is_array($result);
     }
 }

--- a/src/Sqs/SqsJob.php
+++ b/src/Sqs/SqsJob.php
@@ -55,11 +55,13 @@ class SqsJob extends AbstractSqsJob
 
     /**
      * @param $message
+     *
      * @return bool
      */
     private function isJson($message)
     {
         $result = json_decode(trim($message, '"'), true);
+
         return is_array($result);
     }
 }


### PR DESCRIPTION
When i want to publish a message without serializing  (Publisher::withoutSerializing()->publish($eventName, $message)). I can't get it because it is in json format.  This fix allows you to automatically determine the message format.


